### PR TITLE
Feature/apply suffix to labels in deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ When you run `bazel run ///helloworld:mynamespace.apply`, it applies this file i
 | ------------------------- | -------------- | -----------
 | ***cluster***             | `None`         | The name of the cluster in which these manifests will be applied.
 | ***namespace***           | `None`         | The target namespace to assign to all manifests. Any namespace value in the source manifests will be replaced or added if not specified.
-| ***user***                | `{BUILD_USER}` | The user passed to kubectl in .apply rule. Must exist in users ~/.kube/config 
+| ***user***                | `{BUILD_USER}` | The user passed to kubectl in .apply rule. Must exist in users ~/.kube/config
 | ***configmaps_srcs***     | `None`         | A list of files (of any type) that will be combined into configmaps. See [Generating Configmaps](#generating-configmaps).
 | ***configmaps_renaming*** | `None`         | Configmaps/Secrets renaming policy. Could be None or 'hash'. 'hash' renaming policy is used to add a unique suffix to the generated configmap or secret name. All references to the configmap or secret in other manifests will be replaced with the generated name.
 | ***secrets_srcs***        | `None`         | A list of files (of any type) that will be combined into a secret similar to configmaps.
@@ -89,6 +89,10 @@ When you run `bazel run ///helloworld:mynamespace.apply`, it applies this file i
 | ***name_suffix***         | `None`         | Adds suffix to the names of all resources defined in manifests.
 | ***patches***             | `None`         | A list of patch files to overlay the base manifests. See [Base Manifests and Overlays](#base-manifests-and-overlays).
 | ***substitutions***       | `None`         | Does parameter substitution in all the manifests (including configmaps). This should generally be limited to "CLUSTER" and "NAMESPACE" only. Any other replacements should be done with overlays.
+| ***configurations***      | `[]`           | A list of files with [kustomize configurations](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/README.md).
+| ***prefix_suffix_app_labels*** | `False`   | Add the bundled configuration file allowing adding suffix and prefix to labels `app` and `app.kubernetes.io/name` and respective selector in Deployment.
+| ***common_labels***       | `{}`           | A map of labels that should be added to all objects and object templates.
+| ***common_annotations***  | `{}`           | A map of annotations that should be added to all objects and object templates.
 | ***start_tag***           | `"{{"`         | The character start sequence used for substitutions.
 | ***end_tag***             | `"}}"`         | The character end sequence used for substitutions.
 | ***deps***                | `[]`           | A list of dependencies used to drive `k8s_deploy` functionality (i.e. `deps_aliases`).

--- a/examples/helloworld/BUILD
+++ b/examples/helloworld/BUILD
@@ -78,6 +78,7 @@ k8s_deploy(
         "service.yaml",
     ],
     name_suffix = "-canary",
+    prefix_suffix_app_labels = True,
     namespace = NAMESPACE,
     user = USER,
 )

--- a/examples/helloworld/BUILD
+++ b/examples/helloworld/BUILD
@@ -78,8 +78,8 @@ k8s_deploy(
         "service.yaml",
     ],
     name_suffix = "-canary",
-    prefix_suffix_app_labels = True,
     namespace = NAMESPACE,
+    prefix_suffix_app_labels = True,
     user = USER,
 )
 

--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -13,7 +13,7 @@ load(
     _get_runfile_path = "runfile",
 )
 load(
-    "//skylib/kustomize:kustomize.bzl",
+    "@com_adobe_rules_gitops//skylib/kustomize:kustomize.bzl",
     "KustomizeInfo",
     "imagePushStatements",
     "kubectl",
@@ -84,8 +84,12 @@ def k8s_deploy(
         manifests = None,
         name_prefix = None,
         name_suffix = None,
+        prefix_suffix_app_labels = False, # apply kustomize configuration to modify "app" labels in Deployments when name prefix or suffix applied
         patches = None,
         substitutions = {},  # dict of template parameter substitutions. CLUSTER and NAMESPACE parameters are added automatically.
+        configurations = [], # additional kustomize configuration files. rules_gitops provides
+        common_labels = {},  # list of common labels to apply to all objects see commonLabels kustomize docs
+        common_annotations = {},  # list of common annotations to apply to all objects see commonAnnotations kustomize docs
         deps = [],
         deps_aliases = {},
         images = {},
@@ -106,6 +110,8 @@ def k8s_deploy(
 
     if not manifests:
         manifests = native.glob(["*.yaml", "*.yaml.tpl"])
+    if prefix_suffix_app_labels:
+        configurations = configurations + ["@com_adobe_rules_gitops//skylib/kustomize:nameprefix_deployment_labels_config.yaml"]
     for reservedname in ["CLUSTER", "NAMESPACE"]:
         if substitutions.get(reservedname):
             fail("do not put %s in substitutions parameter of k8s_deploy. It will be added autimatically" % reservedname)
@@ -150,6 +156,9 @@ def k8s_deploy(
             end_tag = end_tag,
             name_prefix = name_prefix,
             name_suffix = name_suffix,
+            configurations = configurations,
+            common_labels = common_labels,
+            common_annotations = common_annotations,
             patches = patches,
             objects = objects,
             visibility = visibility,
@@ -213,6 +222,9 @@ def k8s_deploy(
             end_tag = end_tag,
             name_prefix = name_prefix,
             name_suffix = name_suffix,
+            configurations = configurations,
+            common_labels = common_labels,
+            common_annotations = common_annotations,
             patches = patches,
         )
         kubectl(

--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -84,10 +84,10 @@ def k8s_deploy(
         manifests = None,
         name_prefix = None,
         name_suffix = None,
-        prefix_suffix_app_labels = False, # apply kustomize configuration to modify "app" labels in Deployments when name prefix or suffix applied
+        prefix_suffix_app_labels = False,  # apply kustomize configuration to modify "app" labels in Deployments when name prefix or suffix applied
         patches = None,
         substitutions = {},  # dict of template parameter substitutions. CLUSTER and NAMESPACE parameters are added automatically.
-        configurations = [], # additional kustomize configuration files. rules_gitops provides
+        configurations = [],  # additional kustomize configuration files. rules_gitops provides
         common_labels = {},  # list of common labels to apply to all objects see commonLabels kustomize docs
         common_annotations = {},  # list of common annotations to apply to all objects see commonAnnotations kustomize docs
         deps = [],

--- a/skylib/kustomize/BUILD
+++ b/skylib/kustomize/BUILD
@@ -11,6 +11,7 @@
 exports_files([
     "run-all.sh.tpl",
     "kubectl.sh.tpl",
+    "nameprefix_deployment_labels_config.yaml",
 ])
 
 sh_binary(

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -121,6 +121,11 @@ def _kustomize_impl(ctx):
         kustomization_yaml += "nameSuffix: '{}'\n".format(ctx.attr.name_suffix)
         use_stamp = use_stamp or "{" in ctx.attr.name_suffix
 
+    if ctx.attr.configurations:
+        kustomization_yaml += "configurations:\n"
+        for _, f in enumerate(ctx.files.configurations):
+            kustomization_yaml += "- {}/{}\n".format(upupup, f.path)
+
     if ctx.files.patches:
         kustomization_yaml += "patches:\n"
         for _, f in enumerate(ctx.files.patches):
@@ -224,7 +229,7 @@ def _kustomize_impl(ctx):
 
     ctx.actions.run(
         outputs = [ctx.outputs.yaml],
-        inputs = ctx.files.manifests + ctx.files.configmaps_srcs + ctx.files.secrets_srcs + [kustomization_yaml_file] + tmpfiles + ctx.files.patches + ctx.files.deps,
+        inputs = ctx.files.manifests + ctx.files.configmaps_srcs + ctx.files.secrets_srcs + ctx.files.configurations + [kustomization_yaml_file] + tmpfiles + ctx.files.patches + ctx.files.deps,
         executable = script,
         mnemonic = "Kustomize",
         tools = [ctx.executable._kustomize_bin],
@@ -263,6 +268,7 @@ kustomize = rule(
         "start_tag": attr.string(default = "{{"),
         "substitutions": attr.string_dict(default = {}),
         "deps": attr.label_list(default = [], allow_files = True),
+        "configurations": attr.label_list(allow_files = True),
         "_build_user_value": attr.label(
             default = Label("//skylib:build_user_value.txt"),
             allow_single_file = True,

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -17,8 +17,8 @@ load("//skylib:push.bzl", "K8sPushInfo")
 load("//skylib:stamp.bzl", "stamp")
 
 _binaries = {
-    "darwin_amd64": ("https://github.com/kubernetes-sigs/kustomize/releases/download/v3.0.0/kustomize_3.0.0_darwin_amd64", "58bf0cf1fe6839a1463120ced1eae385423efa6437539eb491650db5089c60b9"),
-    "linux_amd64": ("https://github.com/kubernetes-sigs/kustomize/releases/download/v3.0.0/kustomize_3.0.0_linux_amd64", "ef0dbeca85c419891ad0e12f1f9df649b02ceb01517fa9aea0297ef14e400c7a"),
+    "darwin_amd64": ("https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.5/kustomize_v3.5.5_darwin_amd64.tar.gz", "5e286dc6e02c850c389aa3c1f5fc4ff5d70f064e480d49e804f209c717c462bd"),
+    "linux_amd64": ("https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.5/kustomize_v3.5.5_linux_amd64.tar.gz", "23306e0c0fb24f5a9fea4c3b794bef39211c580e4cbaee9e21b9891cb52e73e7"),
 }
 
 def _download_binary_impl(ctx):
@@ -39,7 +39,7 @@ sh_binary(
 """)
 
     filename, sha256 = _binaries[platform]
-    ctx.download(filename, "bin/kustomize", sha256 = sha256, executable = True)
+    ctx.download_and_extract(filename, "bin/", sha256 = sha256)
 
 _download_binary = repository_rule(
     _download_binary_impl,

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -131,6 +131,16 @@ def _kustomize_impl(ctx):
         for _, f in enumerate(ctx.files.patches):
             kustomization_yaml += "- {}/{}\n".format(upupup, f.path)
 
+    if ctx.attr.common_labels:
+        kustomization_yaml += "commonLabels:\n"
+        for k in ctx.attr.common_labels:
+            kustomization_yaml += "  {}: '{}'\n".format(k, ctx.attr.common_labels[k])
+
+    if ctx.attr.common_annotations:
+        kustomization_yaml += "commonAnnotations:\n"
+        for k in ctx.attr.common_annotations:
+            kustomization_yaml += "  {}: '{}'\n".format(k, ctx.attr.common_annotations[k])
+
     kustomization_yaml += "generatorOptions:\n"
 
     kustomization_yaml += "  disableNameSuffixHash: {}\n".format(str(ctx.attr.disable_name_suffix_hash).lower())
@@ -269,6 +279,8 @@ kustomize = rule(
         "substitutions": attr.string_dict(default = {}),
         "deps": attr.label_list(default = [], allow_files = True),
         "configurations": attr.label_list(allow_files = True),
+        "common_labels": attr.string_dict(default = {}),
+        "common_annotations": attr.string_dict(default = {}),
         "_build_user_value": attr.label(
             default = Label("//skylib:build_user_value.txt"),
             allow_single_file = True,

--- a/skylib/kustomize/nameprefix_deployment_labels_config.yaml
+++ b/skylib/kustomize/nameprefix_deployment_labels_config.yaml
@@ -9,5 +9,9 @@ namePrefix:
   kind: Deployment
 - path: spec/template/metadata/labels/app.kubernetes.io\/name
   kind: Deployment
+- path: spec/selector/app
+  kind: Service
+- path: spec/selector/app.kubernetes.io\/name
+  kind: Service
 
 

--- a/skylib/kustomize/nameprefix_deployment_labels_config.yaml
+++ b/skylib/kustomize/nameprefix_deployment_labels_config.yaml
@@ -1,0 +1,13 @@
+
+namePrefix:
+- path: metadata/name
+- path: spec/selector/matchLabels/app
+  kind: Deployment
+- path: spec/template/metadata/labels/app
+  kind: Deployment
+- path: spec/selector/matchLabels/app.kubernetes.io\/name
+  kind: Deployment
+- path: spec/template/metadata/labels/app.kubernetes.io\/name
+  kind: Deployment
+
+

--- a/skylib/kustomize/tests/BUILD
+++ b/skylib/kustomize/tests/BUILD
@@ -264,3 +264,61 @@ file_compare_test(
     expected = "expected_patch.yaml",
     file = ":patch",
 )
+
+#-------------------
+# prefix and suffix for deployments: legacy compatibility
+kustomize(
+    name = "deployment_prefix_compat",
+    manifests = ["deployment_with_labels.yaml"],
+    name_prefix = "prefix-",
+    namespace = "",
+)
+
+file_compare_test(
+    name = "deployment_prefix_compat_test",
+    expected = "expected_deployment_prefix_compat.yaml",
+    file = ":deployment_prefix_compat",
+)
+
+kustomize(
+    name = "deployment_suffix_compat",
+    manifests = ["deployment_with_labels.yaml"],
+    name_suffix = "-suffix",
+    namespace = "",
+)
+
+file_compare_test(
+    name = "deployment_suffix_compat_test",
+    expected = "expected_deployment_suffix_compat.yaml",
+    file = ":deployment_suffix_compat",
+)
+
+#-------------------
+# prefix and suffix for deployments
+kustomize(
+    name = "deployment_prefix",
+    configurations = ["//skylib/kustomize:nameprefix_deployment_labels_config.yaml"],
+    manifests = ["deployment_with_labels.yaml"],
+    name_prefix = "prefix-",
+    namespace = "",
+)
+
+file_compare_test(
+    name = "deployment_prefix_test",
+    expected = "expected_deployment_prefix.yaml",
+    file = ":deployment_prefix",
+)
+
+kustomize(
+    name = "deployment_suffix",
+    configurations = ["//skylib/kustomize:nameprefix_deployment_labels_config.yaml"],
+    manifests = ["deployment_with_labels.yaml"],
+    name_suffix = "-suffix",
+    namespace = "",
+)
+
+file_compare_test(
+    name = "deployment_suffix_test",
+    expected = "expected_deployment_suffix.yaml",
+    file = ":deployment_suffix",
+)

--- a/skylib/kustomize/tests/BUILD
+++ b/skylib/kustomize/tests/BUILD
@@ -322,3 +322,22 @@ file_compare_test(
     expected = "expected_deployment_suffix.yaml",
     file = ":deployment_suffix",
 )
+
+#-------------------
+# common labels and common annotations
+kustomize(
+    name = "common_labels",
+    manifests = [
+        "deployment_with_labels.yaml",
+        "service.yaml"
+    ],
+    common_labels = {"flavor": "canary"},
+    common_annotations = {"ownerTeam": "apps"},
+    namespace = "",
+)
+
+file_compare_test(
+    name = "common_labels_test",
+    expected = "expected_common_labels.yaml",
+    file = ":common_labels",
+)

--- a/skylib/kustomize/tests/BUILD
+++ b/skylib/kustomize/tests/BUILD
@@ -327,12 +327,12 @@ file_compare_test(
 # common labels and common annotations
 kustomize(
     name = "common_labels",
+    common_annotations = {"ownerTeam": "apps"},
+    common_labels = {"flavor": "canary"},
     manifests = [
         "deployment_with_labels.yaml",
-        "service.yaml"
+        "service.yaml",
     ],
-    common_labels = {"flavor": "canary"},
-    common_annotations = {"ownerTeam": "apps"},
     namespace = "",
 )
 

--- a/skylib/kustomize/tests/deployment.yaml
+++ b/skylib/kustomize/tests/deployment.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: myapp
 spec:
+  selector:
+    matchLabels:
+      app: myapp
   template:
     metadata:
       labels:

--- a/skylib/kustomize/tests/deployment_legacy.yaml
+++ b/skylib/kustomize/tests/deployment_legacy.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: myapp
 spec:
+  selector:
+    matchLabels:
+      app: myapp
   template:
     metadata:
       labels:

--- a/skylib/kustomize/tests/deployment_with_labels.yaml
+++ b/skylib/kustomize/tests/deployment_with_labels.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+      - name: myapp
+        image: test-image
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp2
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: myapp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: myapp
+    spec:
+      containers:
+      - name: myapp
+        image: test-image

--- a/skylib/kustomize/tests/expected_common_labels.yaml
+++ b/skylib/kustomize/tests/expected_common_labels.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    ownerTeam: apps
+  labels:
+    flavor: canary
+  name: myapp
+spec:
+  ports:
+  - name: web
+    port: 80
+    targetPort: 8080
+  selector:
+    app: myapp
+    flavor: canary
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    ownerTeam: apps
+  labels:
+    flavor: canary
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: myapp
+      flavor: canary
+  template:
+    metadata:
+      annotations:
+        ownerTeam: apps
+      labels:
+        app: myapp
+        flavor: canary
+    spec:
+      containers:
+      - image: test-image
+        name: myapp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    ownerTeam: apps
+  labels:
+    flavor: canary
+  name: myapp2
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: myapp
+      flavor: canary
+  template:
+    metadata:
+      annotations:
+        ownerTeam: apps
+      labels:
+        app.kubernetes.io/name: myapp
+        flavor: canary
+    spec:
+      containers:
+      - image: test-image
+        name: myapp

--- a/skylib/kustomize/tests/expected_deployment_prefix.yaml
+++ b/skylib/kustomize/tests/expected_deployment_prefix.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefix-myapp
+spec:
+  selector:
+    matchLabels:
+      app: prefix-myapp
+  template:
+    metadata:
+      labels:
+        app: prefix-myapp
+    spec:
+      containers:
+      - image: test-image
+        name: myapp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefix-myapp2
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prefix-myapp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prefix-myapp
+    spec:
+      containers:
+      - image: test-image
+        name: myapp

--- a/skylib/kustomize/tests/expected_deployment_prefix_compat.yaml
+++ b/skylib/kustomize/tests/expected_deployment_prefix_compat.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefix-myapp
+spec:
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+      - image: test-image
+        name: myapp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefix-myapp2
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: myapp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: myapp
+    spec:
+      containers:
+      - image: test-image
+        name: myapp

--- a/skylib/kustomize/tests/expected_deployment_suffix.yaml
+++ b/skylib/kustomize/tests/expected_deployment_suffix.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-suffix
+spec:
+  selector:
+    matchLabels:
+      app: myapp-suffix
+  template:
+    metadata:
+      labels:
+        app: myapp-suffix
+    spec:
+      containers:
+      - image: test-image
+        name: myapp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp2-suffix
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: myapp-suffix
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: myapp-suffix
+    spec:
+      containers:
+      - image: test-image
+        name: myapp

--- a/skylib/kustomize/tests/expected_deployment_suffix_compat.yaml
+++ b/skylib/kustomize/tests/expected_deployment_suffix_compat.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-suffix
+spec:
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+      - image: test-image
+        name: myapp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp2-suffix
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: myapp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: myapp
+    spec:
+      containers:
+      - image: test-image
+        name: myapp

--- a/skylib/kustomize/tests/expected_image_resolved_test.yaml
+++ b/skylib/kustomize/tests/expected_image_resolved_test.yaml
@@ -26,6 +26,9 @@ kind: Deployment
 metadata:
   name: myapp
 spec:
+  selector:
+    matchLabels:
+      app: myapp
   template:
     metadata:
       labels:

--- a/skylib/kustomize/tests/expected_patch.yaml
+++ b/skylib/kustomize/tests/expected_patch.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: myapp
 spec:
+  selector:
+    matchLabels:
+      app: myapp
   template:
     metadata:
       labels:

--- a/skylib/kustomize/tests/expected_raw_test.yaml
+++ b/skylib/kustomize/tests/expected_raw_test.yaml
@@ -26,6 +26,9 @@ kind: Deployment
 metadata:
   name: myapp
 spec:
+  selector:
+    matchLabels:
+      app: myapp
   template:
     metadata:
       labels:


### PR DESCRIPTION

It is a common use case to generate multiple variants of the same deployment (canary and prod for example) that would work in the same namespace without interfering. This PR provides two different ways of achieving this.
First, use `prefix_suffix_app_labels` attriblute of k8s_deploy to apply a kustomize configuration including following paths into prefix and suffix transformations:
`spec/selector/matchLabels/app`
`spec/template/metadata/labels/app`
`spec/selector/matchLabels/app.kubernetes.io/name`
`spec/template/metadata/labels/app.kubernetes.io/name`

this will allow changing deployment pod template labels along with object name change while using prefix and postfix transformations.
Second alternative is to use common_labels as in
```
   common_labels = {'environment': 'canary'},
```
to add specified label to all objects, templates and selectors.

## Related Issue
This PR fixes #18 



