### PR TITLE
remove deprecated parameter

### DIFF
--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -93,7 +93,6 @@ def k8s_deploy(
         deps = [],
         deps_aliases = {},
         images = {},
-        image_chroot = None,  # DEPRECATED. ignored now. If default repo path is not working for you, use image_repository to change it
         image_registry = "docker.io",  # registry to push container to. jenkins will need an access configured for gitops to work. Ignored for mynamespace.
         image_repository = None,  # repository (registry path) to push container to. Generated from the image bazel path if empty.
         image_repository_prefix = None,  # Mutually exclusive with 'image_repository'. Add a prefix to the repository name generated from the image bazel path
@@ -121,8 +120,6 @@ def k8s_deploy(
     # NAMESPACE substitution is deferred until test_setup/kubectl/gitops
     if namespace == "{BUILD_USER}":
         gitops = False
-    if image_chroot:
-        print("image_chroot parameter of k8s_deploy rule in %s is ignored now. If default repo path is not working for you, use image_repository to change it." % native.package_name())
     if not gitops:
         # Mynamespace option
         if not namespace:


### PR DESCRIPTION
this PR removes deprecated image_chroot parameter and turns DEBUG level warnings into build time errors if image_chroot is used anywhere.