### PR TITLE
optionally tag the image with the image digest instead of a fixed tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ When you run `bazel run ///helloworld:mynamespace.apply`, it applies this file i
 | ***deps_aliases***        | `{}`           | A dict of labels of file dependencies. File dependency contents are available for template expansion in manifests as `{{imports.<label>}}`. Each dependency in this dictionary should be present in the `deps` attribute.
 | ***objects***             | `[]`           | A list of other instances of `k8s_deploy` that this one depends on. See [Adding Dependencies](#adding-dependencies).
 | ***images***              | `{}`           | A dict of labels of Docker images. See [Injecting Docker Images](#injecting-docker-images).
+| ***image_digest_tag***    | `False`        | A flag for whether or not to tag the image with the container digest.
 | ***image_registry***      | `docker.io`    | The registry to push images to. 
 | ***image_repository***    | `None`         | The repository to push images to. By default, this is generated from the current package path.
 | ***image_repository_prefix*** | `None`     | Add a prefix to the image_repository. Can be used to upload the images in

--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -93,6 +93,7 @@ def k8s_deploy(
         deps = [],
         deps_aliases = {},
         images = {},
+        image_digest_tag = False,
         image_registry = "docker.io",  # registry to push container to. jenkins will need an access configured for gitops to work. Ignored for mynamespace.
         image_repository = None,  # repository (registry path) to push container to. Generated from the image bazel path if empty.
         image_repository_prefix = None,  # Mutually exclusive with 'image_repository'. Add a prefix to the repository name generated from the image bazel path
@@ -132,6 +133,7 @@ def k8s_deploy(
                 k8s_container_push(
                     name = imgname + "_mynamespace_push",
                     image = img,
+                    image_digest_tag = image_digest_tag,
                     legacy_image_name = imgname,
                     registry = image_registry,
                     repository = image_repository,
@@ -196,6 +198,7 @@ def k8s_deploy(
                 k8s_container_push(
                     name = imgname + "_push",
                     image = img,
+                    image_digest_tag = image_digest_tag,
                     legacy_image_name = imgname,
                     registry = image_registry,
                     repository = image_repository,

--- a/skylib/push.bzl
+++ b/skylib/push.bzl
@@ -93,7 +93,7 @@ def _impl(ctx):
     )
 
     if ctx.attr.image_digest_tag:
-        tag = "$(cat {} | sed 's/sha256://')".format(ctx.outputs.digest.path.replace('_push', ''))
+        tag = "$(cat {} | sed 's/sha256://')".format(ctx.outputs.digest.path.replace("_push", ""))
 
     pusher_args.append("--format={}".format(ctx.attr.format))
     pusher_args.append("--dst={registry}/{repository}:{tag}".format(
@@ -178,7 +178,7 @@ Args:
         "image_digest_tag": attr.bool(
             default = False,
             mandatory = False,
-            doc = "Tag the image with the container digest, default to False"
+            doc = "Tag the image with the container digest, default to False",
         ),
         "legacy_image_name": attr.string(doc = "image name used in deployments, for compatibility with k8s_deploy. Do not use, refer images by full bazel target name instead"),
         "registry": attr.string(


### PR DESCRIPTION
## Description

This allows you to optionally set an image tag to be the digest of the image. This is necessary for tools like Artifactory that sometimes cleans out old sha(s) that are not part of a tag (e.g., older `latest` tags).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Tests are failing on master :(