### PR TITLE
create image push targets per repository path

### DIFF
--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -83,7 +83,7 @@ def _image_pushes(name_suffix, images, image_registry, image_repository, image_r
             rule_name_parts.append(image_repository)
         rule_name_parts.append(image_name)
         rule_name = "-".join(rule_name_parts)
-        rule_name = rule_name.replace("/", "-")
+        rule_name = rule_name.replace("/", "-").replace(":", "-")
         image_pushes.append(rule_name + name_suffix)
         if not native.existing_rule(rule_name + name_suffix):
             k8s_container_push(

--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -83,7 +83,7 @@ def _image_pushes(name_suffix, images, image_registry, image_repository, image_r
             rule_name_parts.append(image_repository)
         rule_name_parts.append(image_name)
         rule_name = "-".join(rule_name_parts)
-        rule_name = rule_name.replace("/","-")
+        rule_name = rule_name.replace("/", "-")
         image_pushes.append(rule_name + name_suffix)
         if not native.existing_rule(rule_name + name_suffix):
             k8s_container_push(


### PR DESCRIPTION
## Description

Create one push target per repository path to accommodate situation when the same image target need to be used in multiple `k8s_deploy` targets that configured to push to the different image repositories

Before:

```
//kube/deploybot:deploybot_1_18_x_mynamespace_push
//kube/deploybot:deploybot_1_17_x_mynamespace_push
//kube/deploybot:deploybot_1_18_x_push
//kube/deploybot:deploybot_1_17_x_push
```

After:

```
//kube/deploybot:cr.example.com-deploybot_1_18_x.push
//kube/deploybot:cr.example.com-deploybot_1_17_x.push
//kube/deploybot:cr.k8s.example.info-deploybot_1_18_x-mynamespace.push
//kube/deploybot:cr.k8s.example.info-deploybot_1_17_x-mynamespace.push
//kube/deploybot:cr.k8s.example.info-deploybot_1_18_x.push
//kube/deploybot:cr.k8s.example.info-deploybot_1_17_x.push
```