### PR TITLE
use the image['digest'].path to get the image digest value

### DIFF
--- a/skylib/push.bzl
+++ b/skylib/push.bzl
@@ -93,7 +93,7 @@ def _impl(ctx):
     )
 
     if ctx.attr.image_digest_tag:
-        tag = "$(cat {} | cut -d ':' -f 2 | cut -c 1-7)".format(ctx.outputs.digest.path)
+        tag = "$(cat {} | sed 's/sha256://')".format(image["digest"].path)
 
     pusher_args.append("--format={}".format(ctx.attr.format))
     pusher_args.append("--dst={registry}/{repository}:{tag}".format(


### PR DESCRIPTION
## Description

use the `image['digest'].path` to get the image digest value. This fixes when the image name doesn't match the variable name.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
