### PR TITLE
Allow using custom kubectl binary

### DIFF
--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -16,7 +16,7 @@ load(
     "@com_adobe_rules_gitops//skylib/kustomize:kustomize.bzl",
     "KustomizeInfo",
     "imagePushStatements",
-    "kubectl",
+    kustomize_kubectl = "kubectl",
     "kustomize",
     kustomize_gitops = "gitops",
 )
@@ -128,6 +128,7 @@ def k8s_deploy(
         flatten_manifest_directories = False,
         start_tag = "{{",
         end_tag = "}}",
+        kubectl = None,
         visibility = None):
     """ k8s_deploy
     """
@@ -181,15 +182,16 @@ def k8s_deploy(
             objects = objects,
             visibility = visibility,
         )
-        kubectl(
+        kustomize_kubectl(
             name = name + ".apply",
             srcs = [name],
             cluster = cluster,
             user = user,
             namespace = namespace,
+            kubectl = kubectl,
             visibility = visibility,
         )
-        kubectl(
+        kustomize_kubectl(
             name = name + ".delete",
             srcs = [name],
             command = "delete",
@@ -197,6 +199,7 @@ def k8s_deploy(
             push = False,
             user = user,
             namespace = namespace,
+            kubectl = kubectl,
             visibility = visibility,
         )
         show(
@@ -239,12 +242,13 @@ def k8s_deploy(
             common_annotations = common_annotations,
             patches = patches,
         )
-        kubectl(
+        kustomize_kubectl(
             name = name + ".apply",
             srcs = [name],
             cluster = cluster,
             user = user,
             namespace = namespace,
+            kubectl = kubectl,
             visibility = visibility,
         )
         kustomize_gitops(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a `kubectl` attribute to k8s_deploy, allowing to specify a custom
kubectl binary.

Fix #33

## Related Issue

https://github.com/adobe/rules_gitops/issues/33

## Motivation and Context

Allows for easily wrapping or sandboxing the `kubectl` binary.

## How Has This Been Tested?

Tested locally on macOS with a k3s cluster running in Docker for Mac.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
