### PR TITLE
image substitution via templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,25 @@ spec:
     - name: java_container
       image: registry.example.com/examples/image@sha256:c94d75d68f4c1b436f545729bbce82774fda07
 ```
+Image substitutions for Custom Resource Definitions (CRD) resources could also use target references directly. For example,
+```yaml
+apiVersion: v1
+kind: MyCrd
+metadata:
+  name: my_crd
+spec:
+  image: "{{//example:my_image}}"
+```
+would become 
+```yaml
+apiVersion: v1
+kind: MyCrd
+metadata:
+  name: my_crd
+spec:
+  image: registry.example.com/examples/my_image@sha256:e6d465223da74519ba3e2b38179d1268b71a72f
+```
+
 That URL points to the "some_java_image" in the private Docker registry. The image is uploaded to the registry before any `.apply` or `.gitops` target is executed.
 
 As with the rest of the dependency graph, Bazel understands the dependencies `k8s_deploy` has on the

--- a/examples/helloworld/deployment.yaml
+++ b/examples/helloworld/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: helloworld-image
+        image: "{{helloworld-image}}"
         args:
           - --port=8080
         ports:

--- a/examples/helloworld/deployment.yaml
+++ b/examples/helloworld/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: "{{helloworld-image}}"
+        image: helloworld-image
         args:
           - --port=8080
         ports:

--- a/resolver/pkg/resolver.go
+++ b/resolver/pkg/resolver.go
@@ -119,13 +119,15 @@ func (pt *imageTagTransformer) updateContainers(obj map[string]interface{}, path
 		if !found {
 			continue
 		}
-		imagename := image.(string)
-		if newname, ok := pt.images[imagename]; ok {
-			container["image"] = newname
-			continue
-		}
-		if strings.HasPrefix(imagename, "//") {
-			return fmt.Errorf("Unresolved image found: %s", imagename)
+		imagename, imagenameOk := image.(string)
+		if imagenameOk {
+			if newname, ok := pt.images[imagename]; ok {
+				container["image"] = newname
+				continue
+			}
+			if strings.HasPrefix(imagename, "//") {
+				return fmt.Errorf("Unresolved image found: %s", imagename)
+			}
 		}
 	}
 	return nil
@@ -135,12 +137,14 @@ func (pt *imageTagTransformer) updateContainer(obj map[string]interface{}, path 
 	container := obj[path].(map[string]interface{})
 	image, found := container["image"]
 	if found {
-		imagename := image.(string)
-		if strings.HasPrefix(imagename, "//") {
-			return fmt.Errorf("unresolved image found: %s", imagename)
-		}
-		if newname, ok := pt.images[imagename]; ok {
-			container["image"] = newname
+		imagename, imagenameOk := image.(string)
+		if imagenameOk {
+			if strings.HasPrefix(imagename, "//") {
+				return fmt.Errorf("unresolved image found: %s", imagename)
+			}
+			if newname, ok := pt.images[imagename]; ok {
+				container["image"] = newname
+			}
 		}
 	}
 	return nil

--- a/resolver/pkg/resolver_test.go
+++ b/resolver/pkg/resolver_test.go
@@ -37,6 +37,9 @@ func TestNoError(t *testing.T) {
 		{"flinkapp", map[string]string{
 			"flinkapp-image": "docker.io/kube/flink/image:tag",
 		}},
+		{"zk", map[string]string{
+			"zk-image": "dummy",
+		}},
 	}
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {

--- a/resolver/pkg/testdata/zk.expected.yaml
+++ b/resolver/pkg/testdata/zk.expected.yaml
@@ -1,0 +1,8 @@
+apiVersion: zookeeper.pravega.io/v1beta1
+kind: ZookeeperCluster
+metadata:
+  name: zk-cluster
+spec:
+  image:
+    repository: repository
+    tag: 1

--- a/resolver/pkg/testdata/zk.yaml
+++ b/resolver/pkg/testdata/zk.yaml
@@ -1,0 +1,8 @@
+apiVersion: zookeeper.pravega.io/v1beta1
+kind: ZookeeperCluster
+metadata:
+  name: zk-cluster
+spec:
+  image:
+    repository: repository
+    tag: 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add a check to fix a bug when the yaml file has a field named `image` that is not a string
- Add image substitution via templating. This substitution is more flexible and will work without for all custom resource definition.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
