### PR TITLE
Make image hash available for string substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,27 +317,6 @@ Docker image and the files in the image. So for example, here's what will happen
 1. A new "my_pod" manifest will be rendered using the new image
 1. The new "my_pod" will be deployed
 
-<a name="String substitutions"></a>
-### String substitutions
-The substitutions parameter accepts a dictionary. 
-Does parameter substitution in all the manifests (including configmaps). This should generally be limited to "CLUSTER" and "NAMESPACE" only. Any other replacements should be done with overlays.
-
-```yaml
-kind: MyCrd
-metadata:
-  name: my_crd_{{SERVICE_NAME}}
-```
-would become 
-```yaml
-apiVersion: v1
-kind: MyCrd
-metadata:
-  name: my_crd
-spec:
-  image: registry.example.com/examples/my_image@sha256:e6d465223da74519ba3e2b38179d1268b71a72f
-```
-
-
 
 <a name="adding-dependencies"></a>
 ### Adding Dependencies

--- a/examples/helloworld/deployment.yaml
+++ b/examples/helloworld/deployment.yaml
@@ -11,7 +11,6 @@ spec:
     metadata:
       labels:
         app: helloworld
-        app_label_image_digest: "{{//helloworld:image.digest}}"
         app_label_image_short_digest: "{{//helloworld:image.short-digest}}"
     spec:
       containers:

--- a/examples/helloworld/deployment.yaml
+++ b/examples/helloworld/deployment.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         app: helloworld
+        app_label_unique_hash: "{{//helloworld:image__HASH}}"
+        app_label_unique_short_hash: "{{//helloworld:image__SHORT_HASH}}"
     spec:
       containers:
       - name: helloworld

--- a/examples/helloworld/deployment.yaml
+++ b/examples/helloworld/deployment.yaml
@@ -11,8 +11,8 @@ spec:
     metadata:
       labels:
         app: helloworld
-        app_label_unique_hash: "{{//helloworld:image__HASH}}"
-        app_label_unique_short_hash: "{{//helloworld:image__SHORT_HASH}}"
+        app_label_image_digest: "{{//helloworld:image.digest}}"
+        app_label_image_short_digest: "{{//helloworld:image.short-digest}}"
     spec:
       containers:
       - name: helloworld

--- a/examples/helloworld/k8s_deploy_test.sh
+++ b/examples/helloworld/k8s_deploy_test.sh
@@ -32,6 +32,8 @@ grep -F "kind: Deployment" mynamespace.show
 grep -F "kind: Service" mynamespace.show
 grep -F "name: helloworld" mynamespace.show
 grep -E "image: localhost:5000/.*/helloworld/image@sha256" mynamespace.show
+grep -E "app_label_image_digest" mynamespace.show | grep -v -F 'image.digest'
+grep -E "app_label_image_short_digest" mynamespace.show | grep -v -F 'image.short-digest'
 
 $(rlocation examples/helloworld/canary.show) > canary.show
 echo "DEBUG: canary.show:"

--- a/examples/helloworld/k8s_deploy_test.sh
+++ b/examples/helloworld/k8s_deploy_test.sh
@@ -32,7 +32,6 @@ grep -F "kind: Deployment" mynamespace.show
 grep -F "kind: Service" mynamespace.show
 grep -F "name: helloworld" mynamespace.show
 grep -E "image: localhost:5000/.*/helloworld/image@sha256" mynamespace.show
-grep -E "app_label_image_digest" mynamespace.show | grep -v -F 'image.digest'
 grep -E "app_label_image_short_digest" mynamespace.show | grep -v -F 'image.short-digest'
 
 $(rlocation examples/helloworld/canary.show) > canary.show

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -92,7 +92,6 @@ _script_template = """\
 set -euo pipefail
 {kustomize} build --load_restrictor none --reorder legacy {kustomize_dir} {template_part} {resolver_part} >{out}
 """
-
 KustomizeInfo = provider(fields = [
     "image_pushes",
 ])
@@ -236,8 +235,8 @@ def _kustomize_impl(ctx):
                 template_part += " --variable={}={}@$(cat {})".format(kpi.image_label, regrepo, kpi.digestfile.path)
 
                 # Image digest
-                template_part += " --variable={}=$(cat {} | cut -d ':' -f 2)".format(str(kpi.image_label)+".digest", kpi.digestfile.path)
-                template_part += " --variable={}=$(cat {} | cut -c 8-17)".format(str(kpi.image_label)+".short-digest", kpi.digestfile.path)
+                template_part += " --variable={}=$(cat {} | cut -d ':' -f 2)".format(str(kpi.image_label) + ".digest", kpi.digestfile.path)
+                template_part += " --variable={}=$(cat {} | cut -c 8-17)".format(str(kpi.image_label) + ".short-digest", kpi.digestfile.path)
 
                 if kpi.legacy_image_name:
                     template_part += " --variable={}={}@$(cat {})".format(kpi.legacy_image_name, regrepo, kpi.digestfile.path)

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -254,8 +254,6 @@ def _kustomize_impl(ctx):
     )
     ctx.actions.write(script, script_content, is_executable = True)
 
-    print(script_content)
-
     ctx.actions.run(
         outputs = [ctx.outputs.yaml],
         inputs = ctx.files.manifests + ctx.files.configmaps_srcs + ctx.files.secrets_srcs + ctx.files.configurations + [kustomization_yaml_file] + tmpfiles + ctx.files.patches + ctx.files.deps,

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -235,9 +235,9 @@ def _kustomize_impl(ctx):
                     regrepo = stamp(ctx, regrepo, tmpfiles, ctx.attr.name + regrepo.replace("/", "_"))
                 template_part += " --variable={}={}@$(cat {})".format(kpi.image_label, regrepo, kpi.digestfile.path)
 
-                # Image hash
-                template_part += " --variable={}=$(cat {} | awk '{{print substr($1,8)}}')".format(str(kpi.image_label)+"__HASH", kpi.digestfile.path)
-                template_part += " --variable={}=$(cat {} | awk '{{print substr($1,8,13)}}')".format(str(kpi.image_label)+"__SHORT_HASH", kpi.digestfile.path)
+                # Image digest
+                template_part += " --variable={}=$(cat {} | cut -d ':' -f 2)".format(str(kpi.image_label)+".digest", kpi.digestfile.path)
+                template_part += " --variable={}=$(cat {} | cut -c 8-17)".format(str(kpi.image_label)+".short-digest", kpi.digestfile.path)
 
                 if kpi.legacy_image_name:
                     template_part += " --variable={}={}@$(cat {})".format(kpi.legacy_image_name, regrepo, kpi.digestfile.path)
@@ -253,6 +253,8 @@ def _kustomize_impl(ctx):
         out = ctx.outputs.yaml.path,
     )
     ctx.actions.write(script, script_content, is_executable = True)
+
+    print(script_content)
 
     ctx.actions.run(
         outputs = [ctx.outputs.yaml],

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -234,6 +234,11 @@ def _kustomize_impl(ctx):
                 if "{" in regrepo:
                     regrepo = stamp(ctx, regrepo, tmpfiles, ctx.attr.name + regrepo.replace("/", "_"))
                 template_part += " --variable={}={}@$(cat {})".format(kpi.image_label, regrepo, kpi.digestfile.path)
+
+                # Image hash
+                template_part += " --variable={}=$(cat {} | awk '{{print substr($1,8)}}')".format(str(kpi.image_label)+"__HASH", kpi.digestfile.path)
+                template_part += " --variable={}=$(cat {} | awk '{{print substr($1,8,13)}}')".format(str(kpi.image_label)+"__SHORT_HASH", kpi.digestfile.path)
+
                 if kpi.legacy_image_name:
                     template_part += " --variable={}={}@$(cat {})".format(kpi.legacy_image_name, regrepo, kpi.digestfile.path)
 


### PR DESCRIPTION
This allows deployment files to get a unique identifier based on the content of the deployment (container image).