### PR TITLE
Ensure bash shebang lines are portable

### DIFF
--- a/create_kind_cluster.sh
+++ b/create_kind_cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy

--- a/examples/e2e-test.sh
+++ b/examples/e2e-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy

--- a/examples/helloworld/k8s_deploy_test.sh
+++ b/examples/helloworld/k8s_deploy_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Debug
 # set -x

--- a/skylib/cmd.sh.tpl
+++ b/skylib/cmd.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy

--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -29,7 +29,7 @@ def _python_runfiles(ctx, f):
     return "PYTHON_RUNFILES=${RUNFILES} %s" % _runfiles(ctx, f)
 
 def _show_impl(ctx):
-    script_content = "#!/bin/bash\nset -e\n"
+    script_content = "#!/usr/bin/env bash\nset -e\n"
 
     kustomize_outputs = []
     script_template = "{template_engine} --template={infile} --variable=NAMESPACE={namespace} --stamp_info_file={info_file}\n"

--- a/skylib/k8s_cmd.sh.tpl
+++ b/skylib/k8s_cmd.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy

--- a/skylib/k8s_gitops.sh.tpl
+++ b/skylib/k8s_gitops.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy

--- a/skylib/k8s_test_namespace.sh.tpl
+++ b/skylib/k8s_test_namespace.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -88,7 +88,7 @@ def _is_ignored_src(src):
     return basename.startswith(".")
 
 _script_template = """\
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 {kustomize} build --load_restrictor none --reorder legacy {kustomize_dir} {template_part} {resolver_part} >{out}
 """

--- a/skylib/kustomize/run-all.sh.tpl
+++ b/skylib/kustomize/run-all.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/skylib/kustomize/set_namespace.sh
+++ b/skylib/kustomize/set_namespace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash +x
+#!/usr/bin/env bash
 # Copyright 2020 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy
@@ -8,6 +8,8 @@
 # the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 # OF ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
+
+set +x
 
 if [ "$1" == "" ]; then
     echo usage:

--- a/skylib/kustomize/tests/set_namespace_test.sh
+++ b/skylib/kustomize/tests/set_namespace_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function test_namespace_replaced {

--- a/skylib/tests/fork_join_test.sh
+++ b/skylib/tests/fork_join_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function test_dedupe {


### PR DESCRIPTION
This commit ensures all instances of bash shebang line are utilizing portable `/usr/bin/env bash`, allowing for greater portability of the rules_gitops

## Related Issue

Fixed #52 

## Motivation and Context

I would like to commit upstream changes which made it possible to run adobe rules_gitops on Linux OS'es which do not have `/bin/bash` executable. 

## How Has This Been Tested?

I have been using patched (in same manner like in this commit) rules_gitops in my projects.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
