### PR TITLE
Ability to tag images from k8s_deploy

### DIFF
--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -73,7 +73,7 @@ show = rule(
     executable = True,
 )
 
-def _image_pushes(name_suffix, images, image_registry, image_repository, image_repository_prefix, image_digest_tag):
+def _image_pushes(name_suffix, images, image_registry, image_repository, image_repository_prefix, image_digest_tag, image_tag):
     image_pushes = []
     for image_name in images:
         image = images[image_name]
@@ -94,6 +94,7 @@ def _image_pushes(name_suffix, images, image_registry, image_repository, image_r
                 registry = image_registry,
                 repository = image_repository,
                 repository_prefix = image_repository_prefix,
+                tag = image_tag,
             )
     return image_pushes
 
@@ -123,6 +124,7 @@ def k8s_deploy(
         image_registry = "docker.io",  # registry to push container to. jenkins will need an access configured for gitops to work. Ignored for mynamespace.
         image_repository = None,  # repository (registry path) to push container to. Generated from the image bazel path if empty.
         image_repository_prefix = None,  # Mutually exclusive with 'image_repository'. Add a prefix to the repository name generated from the image bazel path
+        image_tag = "latest",
         objects = [],
         gitops = True,  # make sure to use gitops = False to work with individual namespace. This option will be turned False if namespace is '{BUILD_USER}'
         gitops_path = "cloud",
@@ -160,6 +162,7 @@ def k8s_deploy(
             image_repository = image_repository,
             image_repository_prefix = "{BUILD_USER}",
             image_digest_tag = image_digest_tag,
+            image_tag = image_tag,
         )
         kustomize(
             name = name,
@@ -221,6 +224,7 @@ def k8s_deploy(
             image_repository = image_repository,
             image_repository_prefix = image_repository_prefix,
             image_digest_tag = image_digest_tag,
+            image_tag = image_tag,
         )
         kustomize(
             name = name,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

k8s_deploy by default will tag images w/ the 'latest' tag.
Sometimes this is undesirable such as when you want to link an
image to a particular release or git SHA.
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/adobe/rules_gitops/issues/74

## Motivation and Context

Allows user to specify which tag they want a container image tagged with.

## How Has This Been Tested?

Tested by running k8s_deploy with a custom image tag to azure container registry

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
