### PR TITLE
Upgrade kustomize to 4.5.3

### DIFF
--- a/skylib/kustomize/BUILD
+++ b/skylib/kustomize/BUILD
@@ -12,6 +12,7 @@ exports_files([
     "run-all.sh.tpl",
     "kubectl.sh.tpl",
     "nameprefix_deployment_labels_config.yaml",
+    "namesuffix_deployment_labels_config.yaml",
 ])
 
 sh_binary(

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -90,7 +90,7 @@ def _is_ignored_src(src):
 _script_template = """\
 #!/usr/bin/env bash
 set -euo pipefail
-{kustomize} build --load_restrictor none --reorder legacy {kustomize_dir} {template_part} {resolver_part} >{out}
+{kustomize} build --load-restrictor LoadRestrictionsNone --reorder legacy {kustomize_dir} {template_part} {resolver_part} >{out}
 """
 KustomizeInfo = provider(fields = [
     "image_pushes",

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -17,8 +17,8 @@ load("//skylib:push.bzl", "K8sPushInfo")
 load("//skylib:stamp.bzl", "stamp")
 
 _binaries = {
-    "darwin_amd64": ("https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.5/kustomize_v3.5.5_darwin_amd64.tar.gz", "5e286dc6e02c850c389aa3c1f5fc4ff5d70f064e480d49e804f209c717c462bd"),
-    "linux_amd64": ("https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.5/kustomize_v3.5.5_linux_amd64.tar.gz", "23306e0c0fb24f5a9fea4c3b794bef39211c580e4cbaee9e21b9891cb52e73e7"),
+    "darwin_amd64": ("https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.3/kustomize_v4.5.3_darwin_amd64.tar.gz", "b0a6b0568273d466abd7cd535c556e44aa9ff5f54c07e86ed9f3016b416de992"),
+    "linux_amd64": ("https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.3/kustomize_v4.5.3_linux_amd64.tar.gz", "e4dc2f795235b03a2e6b12c3863c44abe81338c5c0054b29baf27dcc734ae693"),
 }
 
 def _download_binary_impl(ctx):

--- a/skylib/kustomize/nameprefix_deployment_labels_config.yaml
+++ b/skylib/kustomize/nameprefix_deployment_labels_config.yaml
@@ -13,5 +13,3 @@ namePrefix:
   kind: Service
 - path: spec/selector/app.kubernetes.io\/name
   kind: Service
-
-

--- a/skylib/kustomize/namesuffix_deployment_labels_config.yaml
+++ b/skylib/kustomize/namesuffix_deployment_labels_config.yaml
@@ -1,0 +1,15 @@
+
+nameSuffix:
+  - path: metadata/name
+  - path: spec/selector/matchLabels/app
+    kind: Deployment
+  - path: spec/template/metadata/labels/app
+    kind: Deployment
+  - path: spec/selector/matchLabels/app.kubernetes.io\/name
+    kind: Deployment
+  - path: spec/template/metadata/labels/app.kubernetes.io\/name
+    kind: Deployment
+  - path: spec/selector/app
+    kind: Service
+  - path: spec/selector/app.kubernetes.io\/name
+    kind: Service

--- a/skylib/kustomize/tests/BUILD
+++ b/skylib/kustomize/tests/BUILD
@@ -385,7 +385,7 @@ file_compare_test(
 
 kustomize(
     name = "deployment_suffix",
-    configurations = ["//skylib/kustomize:nameprefix_deployment_labels_config.yaml"],
+    configurations = ["//skylib/kustomize:namesuffix_deployment_labels_config.yaml"],
     manifests = ["deployment_with_labels.yaml"],
     name_suffix = "-suffix",
     namespace = "",

--- a/testing/it_sidecar/client/sidecar_client.go
+++ b/testing/it_sidecar/client/sidecar_client.go
@@ -55,9 +55,11 @@ func (s *K8STestSetup) TestMain(m *testing.M) {
 			}
 		}()
 		s.before(wg)
-		err := s.ReadyCallback()
-		if err != nil {
-			log.Fatal(err)
+		if s.ReadyCallback != nil {
+			err := s.ReadyCallback()
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 
 		// Run tests.


### PR DESCRIPTION
## Description
Upgrades kustomize to 4.5.3 (from 3.5.5). Also separates out prefix and suffix deployment labels config into separate configs

## Motivation and Context
Motivation is to resolve issue with `batch/v1` CronJob patching behavior (fixed in kustomize 4.3.0 [here](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.3.0)).

## How Has This Been Tested?

Passes existing tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
