### PR TITLE
Update push.bzl

### DIFF
--- a/skylib/push.bzl
+++ b/skylib/push.bzl
@@ -132,7 +132,6 @@ def _impl(ctx):
             registry = registry,
             repository = repository,
             tag = tag,
-            stamp_inputs = stamp_inputs,
             digest = image["digest"],
         ),
         K8sPushInfo(


### PR DESCRIPTION
Deleting `stamp_inputs` as well.
On Bazel 5.0, it is failing with
```sh
Traceback (most recent call last):
	File "/home/ajithu/.cache/bazel/_bazel_ajithu/3e767109738c8b2d608cdfe5de369b17/external/com_adobe_rules_gitops/skylib/push.bzl", line 131, column 17, in _impl
		PushInfo(
	File "/home/ajithu/.cache/bazel/_bazel_ajithu/3e767109738c8b2d608cdfe5de369b17/external/io_bazel_rules_docker/container/providers.bzl", line 52, column 20, in PushInfo
		PushInfo = provider(fields = [
Error: unexpected keywords stamp, stamp, stamp, stamp_inputs, tag in call to instantiate provider PushInfo
```

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
