### PR TITLE
--dry_run flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,8 @@ As a result of the setup above the `create_gitops_prs` tool will open up to 2 po
 
 The GitOps pull request is only created (or new commits added) if the `gitops` target changes the state for the target deployment branch. The source pull request will remain open (and keep accumulation GitOps results) until the pull request is merged and source branch is deleted.
 
+`--dry_run` parameter can be used to test the tool without creating any pull requests. The tool will print the list of the potential pull requests. It is recommended to run the tool in the dry run mode as a part of the CI test suite to verify that the tool is configured correctly.
+
 <a name="multiple-release-branches-gitops-workflow"></a>
 ## Multiple Release Branches GitOps Workflow
 

--- a/gitops/prer/create_gitops_prs.go
+++ b/gitops/prer/create_gitops_prs.go
@@ -238,12 +238,17 @@ func main() {
 	wg.Wait()
 
 	if *dryRun {
+		log.Println("dry-run: updated gitops branches: ", updatedGitopsBranches)
 		log.Println("dry-run: skipping push")
-		return
+	} else {
+		workdir.Push(updatedGitopsBranches)
 	}
-	workdir.Push(updatedGitopsBranches)
 
 	for _, branch := range updatedGitopsBranches {
+		if *dryRun {
+			log.Println("dry-run: skipping PR creation: branch ", branch, "into ", *prInto)
+			continue
+		}
 		err := gitServer.CreatePR(branch, *prInto, fmt.Sprintf("GitOps deployment %s", branch))
 		if err != nil {
 			log.Fatal("unable to create PR: ", err)

--- a/gitops/prer/create_gitops_prs.go
+++ b/gitops/prer/create_gitops_prs.go
@@ -68,6 +68,7 @@ var (
 	gitopsKind             SliceFlags
 	gitopsRuleName         SliceFlags
 	gitopsRuleAttr         SliceFlags
+	dryRun                 = flag.Bool("dry_run", false, "Do not create PRs, just print what would be done")
 )
 
 func init() {
@@ -236,6 +237,10 @@ func main() {
 	close(targetsCh)
 	wg.Wait()
 
+	if *dryRun {
+		log.Println("dry-run: skipping push")
+		return
+	}
 	workdir.Push(updatedGitopsBranches)
 
 	for _, branch := range updatedGitopsBranches {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

it is really hard to test gitops workflow without exposing some kind of secret allowing to push to the repo. `--dry_run` flag would allow to perform everything but the actual push and PR execution.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
