### PR TITLE
k8s_deploy: Allow overriding image_repository_prefix even if gitops = False

### DIFF
--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -74,7 +74,7 @@ def _image_pushes(name_suffix, images, image_registry, image_repository, image_r
     image_pushes = []
 
     def process_image(image_label, legacy_name = None):
-        rule_name_parts = [image_label, image_registry, image_repository, legacy_name]
+        rule_name_parts = [image_label, image_registry, image_repository_prefix, image_repository, legacy_name]
         rule_name_parts = [p for p in rule_name_parts if p]
         rule_name = "_".join(rule_name_parts)
         rule_name = rule_name.replace("/", "_").replace(":", "_")
@@ -163,12 +163,14 @@ def k8s_deploy(
         # Mynamespace option
         if not namespace:
             namespace = "{BUILD_USER}"
+        if image_repository_prefix == None:
+            image_repository_prefix = "{BUILD_USER}"
         image_pushes = _image_pushes(
             name_suffix = "-mynamespace.push",
             images = images,
             image_registry = image_registry,
             image_repository = image_repository,
-            image_repository_prefix = "{BUILD_USER}",
+            image_repository_prefix = image_repository_prefix,
             image_digest_tag = image_digest_tag,
         )
         kustomize(


### PR DESCRIPTION
This can be useful if you want to have more control over the destination of these containers rather than just {BUILD_USER}.

## Description

Currently, if `gitops = False` we force `image_repository_prefix` to be `{BUILD_USER}`. This change makes it so that `image_repository_prefix` will only be set to `{BUILD_USER}` if it is `None`, which it is by default. Therefore, there should be no change for anyone who is not intentionally setting this value.

## Motivation and Context

This can be useful if you want to have more control over the destination of these containers rather than just {BUILD_USER}.

## How Has This Been Tested?

I set a k8s_deployment with gitops false and set the image_repository_prefix and saw the change take effect.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
