### PR TITLE
Fix cluster override in k8s_test_setup

### DIFF
--- a/skylib/k8s.bzl
+++ b/skylib/k8s.bzl
@@ -481,7 +481,7 @@ def _k8s_test_setup_impl(ctx):
     # add files referenced by rule attributes to runfiles
     files = [ctx.executable._stamper, ctx.file.kubectl, ctx.file.kubeconfig, ctx.executable._kustomize, ctx.executable._it_sidecar, ctx.executable._it_manifest_filter]
     files += ctx.files._set_namespace
-    files += ctx.files._cluster
+    files += ctx.files.cluster
 
     push_statements, files, pushes_runfiles = imagePushStatements(ctx, [o for o in ctx.attr.objects if KustomizeInfo in o], files)
 
@@ -505,7 +505,7 @@ def _k8s_test_setup_impl(ctx):
         template = ctx.file._namespace_template,
         substitutions = {
             "%{it_sidecar}": ctx.executable._it_sidecar.short_path,
-            "%{cluster}": ctx.file._cluster.path,
+            "%{cluster}": ctx.file.cluster.path,
             "%{kubeconfig}": ctx.file.kubeconfig.path,
             "%{kubectl}": ctx.file.kubectl.path,
             "%{portforwards}": " ".join(["-portforward=" + p for p in ctx.attr.portforward_services]),
@@ -546,7 +546,7 @@ k8s_test_setup = rule(
         "portforward_services": attr.string_list(),
         "setup_timeout": attr.string(default = "10m"),
         "wait_for_apps": attr.string_list(),
-        "_cluster": attr.label(
+        "cluster": attr.label(
             default = Label("@k8s_test//:cluster"),
             allow_single_file = True,
         ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `k8s_test_setup` rule can inadvertently use the wrong cluster if there is more than one `kubeconfig` defined in the `WORKSPACE`.  It currently has the keyword `_cluster`, which cannot be overridden, as it's private. If there is more than one kubeconfig and it happens to have the name `k8s_test` it will use that instead of the new config that you may define.

The primary issue is that even if you wanted to have a `kubeconfig` with a different name other than `k8s_test`, it will not work as the `_cluster` attributes always assumes the kubeconfig will always use the label `k8s_test`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

1). Allow ability to use a Kubeconfig that doesn't necessarily need to be named `k8s_test`.
2). Allow ability to use multiple Kubeconfigs, where one may be named `k8s_test`.

## How Has This Been Tested?

I have two kubeconfigs, one for our CI cluster, and one for my local cluster running on my Mac as follow:

```
kubeconfig(
    name = "k8s_test",
    cluster = "it-<REDACTED>",
    use_host_config = True,
)

kubeconfig(
    name = "local_test",
    cluster = "kind-kind",
    use_host_config = True,
)
```

This config was then used in k8s_test_setup as follows:

```
k8s_test_setup(
    name = "service_it.setup",
    kubeconfig = "@local_test//:kubeconfig",
    kubectl = "@local_test//:kubectl",
    cluster = "@local_test//:cluster",
    objects = [
       "<REDACTED>"
    ],
)
```

When running associated tests that use `k8s_test_setup`, I can see that the objects are deployed to the "kind-kind" cluster.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
