### PR TITLE
Handle case where returned object from a Watch is not a Pod

### DIFF
--- a/testing/it_sidecar/stern/watch.go
+++ b/testing/it_sidecar/stern/watch.go
@@ -59,7 +59,9 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, con
 					return
 				}
 
-				pod := e.Object.(*corev1.Pod)
+				if pod, ok := e.Object.(*corev1.Pod); !ok {
+					continue
+				}
 
 				if !podFilter.MatchString(pod.Name) {
 					continue

--- a/testing/it_sidecar/stern/watch.go
+++ b/testing/it_sidecar/stern/watch.go
@@ -59,7 +59,11 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, con
 					return
 				}
 
-				if pod, ok := e.Object.(*corev1.Pod); !ok {
+				var (
+					pod *corev1.Pod
+					ok  bool
+				)
+				if pod, ok = e.Object.(*corev1.Pod); !ok {
 					continue
 				}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `Watch` function, when passed in interface of `v1.PodInterface` assumes that the returned type is always of `*corev1.Pod`, this is not always the case and can result in panics. Here is a simple log of a panic that I hit:


```shell
2023-04-17T16:10:31Z | INFO | 2023/04/17 16:10:31 panic: interface conversion: runtime.Object is *v1.Status, not *v1.Pod
2023-04-17T16:10:38Z | INFO | 2023/04/17 16:10:38 
2023-04-17T16:10:38Z | INFO | 2023/04/17 16:10:38 goroutine 101 [running]:
2023-04-17T16:10:38Z | INFO | 2023/04/17 16:10:38 github.com/adobe/rules_gitops/testing/it_sidecar/stern.Watch.func1()
2023-04-17T16:10:38Z | INFO | 2023/04/17 16:10:38 	external/com_adobe_rules_gitops/testing/it_sidecar/stern/watch.go:62 +0x958
2023-04-17T16:10:38Z | INFO | 2023/04/17 16:10:38 created by github.com/adobe/rules_gitops/testing/it_sidecar/stern.Watch
2023-04-17T16:10:38Z | INFO | 2023/04/17 16:10:38 	external/com_adobe_rules_gitops/testing/it_sidecar/stern/watch.go:53 +0x305
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Fix panic.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
