### PR TITLE
docs: remove arguments and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,11 @@ When you run `bazel run ///helloworld:mynamespace.apply`, it applies this file i
 | ***deps***                | `[]`           | A list of dependencies used to drive `k8s_deploy` functionality (i.e. `deps_aliases`).
 | ***deps_aliases***        | `{}`           | A dict of labels of file dependencies. File dependency contents are available for template expansion in manifests as `{{imports.<label>}}`. Each dependency in this dictionary should be present in the `deps` attribute.
 | ***objects***             | `[]`           | A list of other instances of `k8s_deploy` that this one depends on. See [Adding Dependencies](#adding-dependencies).
-| ***images***              | `{}`           | A dict of labels of Docker images. See [Injecting Docker Images](#injecting-docker-images).
+| ***images***              | `{}`           | A dict of labels or array of labels of Docker images. See [Injecting Docker Images](#injecting-docker-images).
 | ***image_digest_tag***    | `False`        | A flag for whether or not to tag the image with the container digest.
 | ***image_registry***      | `docker.io`    | The registry to push images to.
 | ***image_repository***    | `None`         | The repository to push images to. By default, this is generated from the current package path.
 | ***image_repository_prefix*** | `None`     | Add a prefix to the image_repository. Can be used to upload the images in
-| ***image_pushes***        | `[]`           | A list of labels implementing K8sPushInfo referring image uploaded into registry. See [Injecting Docker Images](#injecting-docker-images).
 | ***release_branch_prefix*** | `master`     | A git branch name/prefix. Automatically run GitOps while building this branch. See [GitOps and Deployment](#gitops_and_deployment).
 | ***deployment_branch***   | `None`         | Automatic GitOps output will appear in a branch and PR with this name. See [GitOps and Deployment](#gitops_and_deployment).
 | ***gitops_path***         | `cloud`        | Path within the git repo where gitops files get generated into

--- a/gitops/defs.bzl
+++ b/gitops/defs.bzl
@@ -13,8 +13,8 @@ GitOps rules public interface
 """
 
 load("@com_adobe_rules_gitops//skylib:k8s.bzl", _k8s_deploy = "k8s_deploy", _k8s_test_setup = "k8s_test_setup")
-load("@com_adobe_rules_gitops//skylib:external_image.bzl", _external_iamge = "external_image")
+load("@com_adobe_rules_gitops//skylib:external_image.bzl", _external_image = "external_image")
 
 k8s_deploy = _k8s_deploy
 k8s_test_setup = _k8s_test_setup
-external_image = _external_iamge
+external_image = _external_image


### PR DESCRIPTION
## Description

Removed an argument from the doc that was removed by another commit prior: 041ba72776b3b4a7e72a60f14845b9536a49f20c

## Related Issue

None

## Motivation and Context

Got tricked into using removed image_pushes parameter

## How Has This Been Tested?

Doc update

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
