### PR TITLE
Add new rule 'calculate_digest'

### DIFF
--- a/skylib/digester.bzl
+++ b/skylib/digester.bzl
@@ -1,0 +1,73 @@
+load(
+    "@io_bazel_rules_docker//container:layer_tools.bzl",
+    _gen_img_args = "generate_args_for_image",
+    _get_layers = "get_from_target",
+)
+
+def calc_digest(ctx):
+    """ Calculate the digest for a given image
+
+    Args:
+       ctx: The context
+    Returns:
+        image: The image which has reference to a digest
+    """
+
+    digester_args = []
+    digester_input = []
+
+    image = _get_layers(ctx, ctx.label.name, ctx.attr.image)
+    digester_img_args, digester_img_inputs = _gen_img_args(ctx, image)
+    digester_input += digester_img_inputs
+    digester_args += digester_img_args
+
+    digester_args += ["--dst", str(ctx.outputs.digest.path), "--format", str(ctx.attr.format)]
+
+    ctx.actions.run(
+        inputs = digester_input,
+        outputs = [ctx.outputs.digest],
+        executable = ctx.executable._digester,
+        arguments = digester_args,
+        tools = ctx.attr._digester[DefaultInfo].default_runfiles.files,
+        mnemonic = "CalculateDigest",
+    )
+
+    return image
+
+def _calculate_digest_impl(ctx):
+    calc_digest(ctx)
+
+# Rule definition
+calculate_digest = rule(
+    doc = """
+    Calculates the digest for a container image.
+
+    Args:
+      name: name of the rule
+      image: the label of the image to calculate the digest for.
+      format: The format to process: Docker or OCI.
+    """,
+    implementation = _calculate_digest_impl,
+    attrs = {
+        "format": attr.string(
+            default = "Docker",
+            values = [
+                "OCI",
+                "Docker",
+            ],
+            doc = "The format to process: Docker or OCI, default to 'Docker'.",
+        ),
+        "image": attr.label(
+            mandatory = True,
+            doc = "The label of the image to calculate the digest for.",
+        ),
+        "_digester": attr.label(
+            default = "@io_bazel_rules_docker//container/go/cmd/digester",
+            cfg = "exec",
+            executable = True,
+        ),
+    },
+    outputs = {
+        "digest": "%{name}.digest",
+    },
+)

--- a/skylib/digester.bzl
+++ b/skylib/digester.bzl
@@ -47,7 +47,7 @@ calculate_digest = rule(
       image: the label of the image to calculate the digest for.
       format: The format to process: Docker or OCI.
     """,
-    implementation = _calculate_digest_impl,
+    implementation = _image_digest_impl,
     attrs = {
         "format": attr.string(
             default = "Docker",

--- a/skylib/push.bzl
+++ b/skylib/push.bzl
@@ -21,7 +21,6 @@ load("@io_bazel_rules_docker//container:providers.bzl", "PushInfo")
 load(
     "@io_bazel_rules_docker//container:layer_tools.bzl",
     _gen_img_args = "generate_args_for_image",
-    _get_layers = "get_from_target",
     _layer_tools = "tools",
 )
 load(
@@ -29,7 +28,6 @@ load(
     "runfile",
 )
 load("@com_adobe_rules_gitops//skylib:digester.bzl", "calc_digest")
-
 
 K8sPushInfo = provider(
     "Information required to inject image into a manifest",
@@ -273,4 +271,3 @@ Args:
         "digest": "%{name}.digest",
     },
 )
-

--- a/skylib/push.bzl
+++ b/skylib/push.bzl
@@ -121,7 +121,7 @@ def _impl(ctx):
     pusher_input += stamp_inputs
 
     # Construct container_parts for input to pusher.
-    image = calc_digest(ctx)
+    image = image_digest_action(ctx)
     pusher_img_args, pusher_img_inputs = _gen_img_args(ctx, image, _get_runfile_path)
     pusher_args += pusher_img_args
     pusher_input += pusher_img_inputs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Refactored `push.bzl` to call a new function to run the digester.
- Added a new rule `calculate_digest` to be used to calculate digests for a container image label.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
 Would like to be able to calculate the digest of an image prior to having to push it with `k8s_container_push`.

## How Has This Been Tested?

Confirmed rule `calculate_digest` generates a digest file.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
