### PR TITLE
Allow to set pull request custom title and body

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ if [ "${GIT_BRANCH_NAME}" == "master"]; then
         --git_server github \
         --release_branch master \
         --gitops_pr_into master \
+        --gitops_pr_title "This is my pull request title" \
+        --gitops_pr_body "This is my pull request body message" \
         --branch_name ${GIT_BRANCH_NAME} \
         --git_commit ${GIT_COMMIT_ID} \
 fi
@@ -488,6 +490,8 @@ if [ "${RELEASE_BRANCH}" == "release/team"]; then
         --release_branch ${RELEASE_BRANCH} \
         --deployment_branch_suffix=${RELEASE_BRANCH_SUFFIX} \
         --gitops_pr_into master \
+        --gitops_pr_title "This is my pull request title" \
+        --gitops_pr_body "This is my pull request body message" \
         --branch_name ${GIT_BRANCH_NAME} \
         --git_commit ${GIT_COMMIT_ID} \
 fi

--- a/gitops/git/bitbucket/bitbucket.go
+++ b/gitops/git/bitbucket/bitbucket.go
@@ -63,14 +63,14 @@ type pullrequest struct {
 }
 
 // CreatePR creates a pull request using branch names from and to
-func CreatePR(from, to, title string) error {
+func CreatePR(from, to, title, body string) error {
 	repo := repository{
 		Slug:    "repo",
 		Project: project{"TM"},
 	}
 	prReq := pullrequest{
 		Title:       title,
-		Description: title,
+		Description: body,
 		State:       "OPEN",
 		Open:        true,
 		Closed:      false,
@@ -101,8 +101,8 @@ func CreatePR(from, to, title string) error {
 	}
 	log.Printf("bitbucket api response: %s", resp.Status)
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	log.Print("bitbucket response: ", string(body))
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	log.Print("bitbucket response: ", string(responseBody))
 	// 201 created
 	// 409 already exists
 	if resp.StatusCode == 201 {

--- a/gitops/git/bitbucket/bitbucket_test.go
+++ b/gitops/git/bitbucket/bitbucket_test.go
@@ -25,7 +25,7 @@ func TestCreatePRRemote(t *testing.T) {
 	pass := "*************"
 	bitbucketUser = &user
 	bitbucketPassword = &pass
-	err := CreatePR("deploy/test1", "feature/AP-0000", "test")
+	err := CreatePR("deploy/test1", "feature/AP-0000", "test", "hello world")
 	if err != nil {
 		t.Error("Unexpected error from server: ", err)
 	}
@@ -43,14 +43,14 @@ func TestCreatePRNew(t *testing.T) {
 	oldendpoint := *apiEndpoint
 	defer func() { *apiEndpoint = oldendpoint }()
 	*apiEndpoint = ts.URL
-	err := CreatePR("deploy/test1", "feature/AP-0000", "test")
+	err := CreatePR("deploy/test1", "feature/AP-0000", "test", "hello world")
 	if err != nil {
 		t.Error("Unexpected error from server: ", err)
 	}
 	if srverr != nil {
 		t.Error("Unexpected error: ", srverr)
 	}
-	expectedreq := `{"title":"test","description":"test","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/deploy/test1","repository":{"slug":"repo","project":{"key":"TM"}}},"toRef":{"id":"refs/heads/feature/AP-0000","repository":{"slug":"repo","project":{"key":"TM"}}},"locked":false}`
+	expectedreq := `{"title":"test","description":"hello world","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/deploy/test1","repository":{"slug":"repo","project":{"key":"TM"}}},"toRef":{"id":"refs/heads/feature/AP-0000","repository":{"slug":"repo","project":{"key":"TM"}}},"locked":false}`
 	if string(buf) != expectedreq {
 		t.Error("Unexpected request body: ", string(buf))
 	}

--- a/gitops/git/github/github.go
+++ b/gitops/git/github/github.go
@@ -20,7 +20,7 @@ var (
 	githubEnterpriseHost = flag.String("github_enterprise_host", "", "The host name of the private enterprise github, e.g. git.corp.adobe.com")
 )
 
-func CreatePR(from, to, title string) error {
+func CreatePR(from, to, title, body string) error {
 	if *repoOwner == "" {
 		return errors.New("github_repo_owner must be set")
 	}
@@ -55,7 +55,7 @@ func CreatePR(from, to, title string) error {
 		Title:               &title,
 		Head:                &from,
 		Base:                &to,
-		Body:                &title,
+		Body:                &body,
 		Issue:               nil,
 		MaintainerCanModify: new(bool),
 		Draft:               new(bool),
@@ -74,11 +74,11 @@ func CreatePR(from, to, title string) error {
 
 	// All other github responses
 	defer resp.Body.Close()
-	body, readingErr := ioutil.ReadAll(resp.Body)
+	responseBody, readingErr := ioutil.ReadAll(resp.Body)
 	if readingErr != nil {
 		log.Println("cannot read response body")
 	} else {
-		log.Println("github response: ", string(body))
+		log.Println("github response: ", string(responseBody))
 	}
 
 	return err

--- a/gitops/git/gitlab/gitlab.go
+++ b/gitops/git/gitlab/gitlab.go
@@ -17,7 +17,7 @@ var (
 	accessToken = flag.String("gitlab_access_token", os.Getenv("GITLAB_TOKEN"), "the access token to authenticate requests")
 )
 
-func CreatePR(from, to, title string) error {
+func CreatePR(from, to, title, body string) error {
 	if *accessToken == "" {
 		return errors.New("gitlab_access_token must be set")
 	}
@@ -57,11 +57,11 @@ func CreatePR(from, to, title string) error {
 
 	// All other gitlab responses
 	defer resp.Body.Close()
-	body, readingErr := ioutil.ReadAll(resp.Body)
+	responseBody, readingErr := ioutil.ReadAll(resp.Body)
 	if readingErr != nil {
 		log.Println("cannot read response body")
 	} else {
-		log.Println("gitlab response: ", string(body))
+		log.Println("gitlab response: ", string(responseBody))
 	}
 
 	return err

--- a/gitops/git/gitlab/gitlab_test.go
+++ b/gitops/git/gitlab/gitlab_test.go
@@ -12,6 +12,7 @@ func TestCreatePRRemote(t *testing.T) {
 		from  string
 		to    string
 		title string
+		body  string
 	}
 	tests := []struct {
 		repo    string
@@ -28,11 +29,22 @@ func TestCreatePRRemote(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			repo: "cotocisternas/rules_gitops_gitlab_test",
+			args: args{
+				from:  "feature/gitlab-test",
+				to:    "master",
+				title: "test_gitlab",
+				body:  "hello world",
+			},
+			wantErr: false,
+		},
+		{
 			repo: "petabytecl/subgroup_rules_gitops_gitlab_test/rules_gitops_gitlab_test",
 			args: args{
 				from:  "feature/gitlab-test",
 				to:    "master",
 				title: "test_gitlab",
+				body:  "hello world",
 			},
 			wantErr: false,
 		},
@@ -40,7 +52,7 @@ func TestCreatePRRemote(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.repo, func(t *testing.T) {
 			repo = &tt.repo
-			if err := CreatePR(tt.args.from, tt.args.to, tt.args.title); (err != nil) != tt.wantErr {
+			if err := CreatePR(tt.args.from, tt.args.to, tt.args.title, tt.args.body); (err != nil) != tt.wantErr {
 				t.Errorf("CreatePR() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/gitops/git/server.go
+++ b/gitops/git/server.go
@@ -1,12 +1,15 @@
 package git
 
 type Server interface {
-	CreatePR(from, to, title string) error
+	CreatePR(from, to, title, body string) error
 }
 
-type ServerFunc func(from, to, title string) error
+type ServerFunc func(from, to, title, body string) error
 
-func (f ServerFunc) CreatePR(from, to, title string) error {
-	return f(from, to, title)
+func (f ServerFunc) CreatePR(from, to, title, body string) error {
+	if body == "" {
+		body = title
+	}
+
+	return f(from, to, title, body)
 }
-

--- a/gitops/prer/create_gitops_prs.go
+++ b/gitops/prer/create_gitops_prs.go
@@ -61,6 +61,8 @@ var (
 	target                 = flag.String("target", "//... except //experimental/...", "target to scan. Useful for debugging only")
 	pushParallelism        = flag.Int("push_parallelism", 5, "Number of image pushes to perform concurrently")
 	prInto                 = flag.String("gitops_pr_into", "master", "use this branch as the source branch and target for deployment PR")
+	prBody                 = flag.String("gitops_pr_body", "GitOps deployment <branch>", "a body message for deployment PR")
+	prTitle                = flag.String("gitops_pr_title", "GitOps deployment <branch>", "a title for deployment PR")
 	branchName             = flag.String("branch_name", "unknown", "Branch name to use in commit message")
 	gitCommit              = flag.String("git_commit", "unknown", "Git commit to use in commit message")
 	deploymentBranchSuffix = flag.String("deployment_branch_suffix", "", "suffix to add to all deployment branch names")
@@ -249,7 +251,12 @@ func main() {
 			log.Println("dry-run: skipping PR creation: branch ", branch, "into ", *prInto)
 			continue
 		}
-		err := gitServer.CreatePR(branch, *prInto, fmt.Sprintf("GitOps deployment %s", branch))
+
+		if *prTitle == "" {
+			*prTitle = fmt.Sprintf("GitOps deployment %s", branch)
+		}
+
+		err := gitServer.CreatePR(branch, *prInto, *prTitle, *prBody)
 		if err != nil {
 			log.Fatal("unable to create PR: ", err)
 		}


### PR DESCRIPTION
Hi,

We are using your GitOps rules and would like to add some arguments to the `@com_adobe_rules_gitops//gitops/prer:create_gitops_prs` in order to allow settings a custom title and/or body pull request.

## Description

By default, it continues to act as it is for now by settings the following as title and body: `GitOps deployment <branch>`, but you can also specify:

* `-gitops_pr_title "<your pull request title>"`
* `-gitops_pr_body "<your pull request body>"`

This would be useful for us in order to display a changelog in the pull request body.

## Related Issue

https://github.com/adobe/rules_gitops/issues/136

## Motivation and Context

We would like to add custom information to the pull request such as a changelog.

## How Has This Been Tested?

I've tested it by forking the project and using it in my Bazel project.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
