### PR TITLE
resolver: Don't crash on nil objs

### DIFF
--- a/resolver/pkg/resolver.go
+++ b/resolver/pkg/resolver.go
@@ -112,6 +112,9 @@ func (pt *imageTagTransformer) findAndReplaceTag(obj map[string]interface{}) err
 }
 
 func (pt *imageTagTransformer) updateContainers(obj map[string]interface{}, path string) error {
+	if obj[path] == nil {
+		return nil
+	}
 	containers := obj[path].([]interface{})
 	for i := range containers {
 		container := containers[i].(map[string]interface{})
@@ -134,6 +137,9 @@ func (pt *imageTagTransformer) updateContainers(obj map[string]interface{}, path
 }
 
 func (pt *imageTagTransformer) updateContainer(obj map[string]interface{}, path string) error {
+	if obj[path] == nil {
+		return nil
+	}
 	container := obj[path].(map[string]interface{})
 	image, found := container["image"]
 	if found {

--- a/resolver/pkg/resolver_test.go
+++ b/resolver/pkg/resolver_test.go
@@ -40,6 +40,9 @@ func TestNoError(t *testing.T) {
 		{"zk", map[string]string{
 			"zk-image": "dummy",
 		}},
+		{"emptyinit", map[string]string{
+			"helloworld-image": "docker.io/kube/hello/image:tag",
+		}},
 	}
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {

--- a/resolver/pkg/testdata/emptyinit.expected.yaml
+++ b/resolver/pkg/testdata/emptyinit.expected.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: CronWorkFlow
+metadata:
+  name: aaa
+  namespace: stats-dev
+spec:
+  workflowSpec:
+    metadata:
+      labels:
+        app: app
+    templates:
+      container:
+        image: docker.io/kube/hello/image:tag
+      initContainers: null

--- a/resolver/pkg/testdata/emptyinit.yaml
+++ b/resolver/pkg/testdata/emptyinit.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: CronWorkFlow
+metadata:
+  name: aaa
+  namespace: stats-dev
+spec:
+  workflowSpec:
+    metadata:
+      labels:
+        app: app
+    templates:
+      initContainers:
+      container:
+        image: helloworld-image


### PR DESCRIPTION
If a YAML specifies an empty `initContainers:`, this will crash this code if we also specify yamls. regardless of how pointless this is, this is, it is valid k8s yaml that applies cleanly.

<!--- Describe your changes in detail -->

## Related Issue

Fix #141

## Motivation and Context

Fixes crash

## How Has This Been Tested?

No longer crashes

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
