### PR TITLE
dont skip filtering on static namespace tests

### DIFF
--- a/skylib/k8s_test_namespace.sh.tpl
+++ b/skylib/k8s_test_namespace.sh.tpl
@@ -47,9 +47,6 @@ then
     NAMESPACE=${USER}
     # do not delete namespace after the test is complete
     DELETE_NAMESPACE_FLAG=""
-    # do not perform manifest transformations
-    # test setup should not try to apply modified manifests
-    IT_MANIFEST_FILTER="cat"
 else
     # create random namespace
     DELETE_NAMESPACE_FLAG="-delete_namespace"


### PR DESCRIPTION
## Description
Test manifest filter is responsible for swapping out PVCs for emptyDir.  By disabling the filter on tests that execute in the BUILD_USER static mynamespace we are potentially changing the behavior of tests (may start failing for new reasons related to volume provisioning).  Test behavior should be consistent in either an ephemeral namespace or the BUILD_USER namespace
