### PR TITLE
Add support for running Kustomize on Linux ARM64

### DIFF
--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -45,7 +45,7 @@ sh_binary(
     ctx.download_and_extract(filename, "bin/", sha256 = sha256)
 
 _download_binary = repository_rule(
-    implementation = _download_binary_impl,
+    _download_binary_impl,
 )
 
 def kustomize_setup(name):

--- a/skylib/kustomize/kustomize.bzl
+++ b/skylib/kustomize/kustomize.bzl
@@ -18,11 +18,16 @@ load("//skylib:stamp.bzl", "stamp")
 _binaries = {
     "darwin_amd64": ("https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.3/kustomize_v4.5.3_darwin_amd64.tar.gz", "b0a6b0568273d466abd7cd535c556e44aa9ff5f54c07e86ed9f3016b416de992"),
     "linux_amd64": ("https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.3/kustomize_v4.5.3_linux_amd64.tar.gz", "e4dc2f795235b03a2e6b12c3863c44abe81338c5c0054b29baf27dcc734ae693"),
+    "linux_arm64": ("https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.3/kustomize_v4.5.3_linux_arm64.tar.gz", "97cf7d53214388b1ff2177a56404445f02d8afacb9421339c878c5ac2c8bc2c8"),
 }
 
 def _download_binary_impl(ctx):
     if ctx.os.name == "linux":
-        platform = "linux_amd64"
+        current_architecture = ctx.execute(["uname", "-m"]).stdout.strip()
+        if current_architecture == "aarch64":
+            platform = "linux_arm64"
+        else:
+            platform = "linux_amd64"
     elif ctx.os.name == "mac os x":
         platform = "darwin_amd64"
     else:
@@ -40,7 +45,7 @@ sh_binary(
     ctx.download_and_extract(filename, "bin/", sha256 = sha256)
 
 _download_binary = repository_rule(
-    _download_binary_impl,
+    implementation = _download_binary_impl,
 )
 
 def kustomize_setup(name):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently the `Kustomize` binaries supported only are `amd64` on both operating systems `Linux` and `MacOS`. 

<!--- Describe your changes in detail -->
I executed the command `uname -a` by the [repository_ctx.execute](https://bazel.build/rules/lib/builtins/repository_ctx#execute) to get the current architecture. Based on it either `kustomize_v4.5.3_linux_arm64.tar.gz` or `kustomize_v4.5.3_linux_amd64.tar.gz` will be downloaded.

## Related Issue
https://github.com/adobe/rules_gitops/issues/177

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Generating manifests on Linux operating systems that run on architecture ARM64

## How Has This Been Tested?
It is mentioned here https://github.com/adobe/rules_gitops/issues/177

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
