### PR TITLE
handle image push errors

### DIFF
--- a/skylib/k8s_gitops.sh.tpl
+++ b/skylib/k8s_gitops.sh.tpl
@@ -56,12 +56,12 @@ function async() {
 }
 
 function waitpids() {
-    # Wait for all of the subprocesses, failing the script if any of them failed.
-    if [ "${#PIDS[@]}" != 0 ]; then
-        for pid in ${PIDS[@]}; do
-            wait ${pid}
-        done
-    fi
+  # Wait for all of the subprocesses, returning the exit code of the first failed process.
+  if [ "${#PIDS[@]}" != 0 ]; then
+    for pid in ${PIDS[@]}; do
+      wait ${pid} || return $?
+    done
+  fi
 }
 
 cd $BUILD_WORKSPACE_DIRECTORY
@@ -73,4 +73,6 @@ else
   TARGET_DIR=$BUILD_WORKSPACE_DIRECTORY
 fi
 
+# make sure that the scirpt is immediately exits if any command below fails
+set -o errexit
 %{statements}


### PR DESCRIPTION
## Description

The `.gitops` targets scripts ignore failures in image push sub-procecesses. The change makes the `.gitops` target to fail and return non `0` exit code.

## How Has This Been Tested?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
