### PR TITLE
Fix runfiles merging for `@bazel_tools//tools/bash/runfiles`

### DIFF
--- a/skylib/run_in_workspace.bzl
+++ b/skylib/run_in_workspace.bzl
@@ -52,8 +52,9 @@ cd $(dirname $(readlink {root_file}))
         files = [
             ctx.file.cmd,
             ctx.file.root_file,
-        ] + ctx.files._bash_runfiles,
+        ],
     )
+    runfiles = runfiles.merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
     return [DefaultInfo(runfiles = runfiles)]
 
 _workspace_binary_script = rule(
@@ -67,7 +68,6 @@ _workspace_binary_script = rule(
             allow_single_file = True,
         ),
         "_bash_runfiles": attr.label(
-            allow_files = True,
             default = "@bazel_tools//tools/bash/runfiles",
         ),
     },


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix merging of runfiles of `@bazel_tools//tools/bash/runfiles`.
## Related Issue

## Motivation and Context

This is required in Bazel 8.3.0, where this target gained runfiles.

## How Has This Been Tested?

Covered by existing tests running on Bazel 8.3.0

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
